### PR TITLE
hotfix/sealed-classes

### DIFF
--- a/Assets/Scripts/Player/Input Parser/InputParser.cs
+++ b/Assets/Scripts/Player/Input Parser/InputParser.cs
@@ -6,7 +6,7 @@ using UnityEngine.InputSystem.Processors;
 
 namespace Player.Input_Parser
 {
-    public class InputParser : MonoBehaviour
+    public sealed class InputParser : MonoBehaviour
     {
         private PlayerInput _playerInput;
         private InputActionAsset _inputActionAsset;

--- a/Assets/Scripts/Player/Movement/PlayerMovement.cs
+++ b/Assets/Scripts/Player/Movement/PlayerMovement.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Player.Movement
 {
-    public class PlayerMovement : MonoBehaviour
+    public sealed class PlayerMovement : MonoBehaviour
     { 
         [SerializeField, Range(1,10)] private float movementSpeed;
         


### PR DESCRIPTION
Added sealed to the classes that require it.

[GridList.cs](https://github.com/Team-Swamp/Project-VooDoo/blob/develop/Assets/Scripts/Framework/GridSystem/GridList.cs) Cannot be sealed since it doesn't support the type.